### PR TITLE
Allow tagged templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "extends": "airbnb-base",
   "env": {
     "browser": true,
     "es6": true
@@ -7,8 +8,10 @@ module.exports = {
     "ecmaVersion": 8,
     "sourceType": "module"
   },
-  "extends": "airbnb-base",
-  // "rules": {
-  // 
-  // }
+  "rules": {
+    "no-unused-expressions": ["error", {
+      // This allows us to use hyperHTML (https://www.npmjs.com/package/hyperhtml)
+      allowTaggedTemplates: true,
+    }],
+  },
 };


### PR DESCRIPTION
By default, ESLint's "no-unused-expressions" rule doesn't support template literals in a way they're used by libraries such as hyperHTML (see [discussion](https://github.com/eslint/eslint/issues/7632)). Fortunately, [now there's an ESLint setting](https://github.com/eslint/eslint/commit/3c4a9c4788a01596d89e0fd44ba1a4513ce3e859) that allows us to support hyperHTML without having to disable the whole rule.