### PR TITLE
Add "no-param-reassign" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,5 +13,9 @@ module.exports = {
       // This allows us to use hyperHTML (https://www.npmjs.com/package/hyperhtml)
       allowTaggedTemplates: true,
     }],
+
+    "no-param-reassign": [2, {
+      "props": false,
+    }],
   },
 };


### PR DESCRIPTION
This rule gives developers a little bit more freedom about an issue that can be frustrating. You can read more about the rule [here](https://stackoverflow.com/a/42399879/3266345).

If we would stay conform with the Airbnb standard, that would result in regular headaches, especially for new team members that aren't used to very strict rules. Let's avoid that.